### PR TITLE
Update Makefile to avoid error during fresh install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts
+install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
Updating the Makefile to add a `--no-commit` flag to the `install` script. Otherwise running `make` after cloning the repo (as suggested by the instructions in the README) throws an error.