### PR TITLE
Fixed math comments in src/TSwapPool.sol

### DIFF
--- a/src/TSwapPool.sol
+++ b/src/TSwapPool.sol
@@ -141,9 +141,11 @@ contract TSwapPool is ERC20 {
             // (wethReserves / poolTokenReserves)
             //
             // So we can do some elementary math now to figure out poolTokensToDeposit...
-            // (wethReserves + wethToDeposit) / poolTokensToDeposit = wethReserves
-            // (wethReserves + wethToDeposit)  = wethReserves * poolTokensToDeposit
-            // (wethReserves + wethToDeposit) / wethReserves  =  poolTokensToDeposit
+            // (wethReserves + wethToDeposit) = (poolTokenReserves + poolTokensToDeposit) * (wethReserves / poolTokenReserves)
+            // wethReserves + wethToDeposit  = poolTokenReserves * (wethReserves / poolTokenReserves) + poolTokensToDeposit * (wethReserves / poolTokenReserves)
+            // wethReserves + wethToDeposit = wethReserves + poolTokensToDeposit * (wethReserves / poolTokenReserves)
+            // wethToDeposit / (wethReserves / poolTokenReserves) = poolTokensToDeposit
+            // (wethToDeposit * poolTokenReserves) / wethReserves = poolTokensToDeposit
             uint256 poolTokensToDeposit = getPoolTokensToDepositBasedOnWeth(
                 wethToDeposit
             );


### PR DESCRIPTION
The comments in [line 144](https://github.com/Cyfrin/5-t-swap-audit/blob/f4337615b7eada3d871378ff8b70af08277d3dec/src/TSwapPool.sol#L144) and onwards have incorrect math, leading to an incorrect final equation for the value of `poolTokensToDeposit`. 

However the implementation of the function [`TSwapPool::getPoolTokensToDepositBasedOnWeth`](https://github.com/Cyfrin/5-t-swap-audit/blob/f4337615b7eada3d871378ff8b70af08277d3dec/src/TSwapPool.sol#L424C48-L424C48) is still done using the correct math, so that is not an issue. 

In this pull request I've adjusted the comments to make the math correct. This ensures that the equation in the comment corresponds to the equation used in the mentioned function to calculate `poolTokensToDeposit`.

I'm not sure if this is considered more of an 'extra audit bug' that we leave in the codebase or if it should be updated- but I think leaving the incorrect comment in would lead to a lot of confusion for the future students.