### PR TITLE
fix: remove --no-commit flag from make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include .env
 
-.PHONY: all test clean deploy fund help install snapshot format anvil 
+.PHONY: all test clean deploy fund help install snapshot format anvil
 
 DEFAULT_ANVIL_KEY := 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
@@ -12,14 +12,14 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit
+install :; forge install foundry-rs/forge-std && forge install openzeppelin/openzeppelin-contracts
 
 # Update Dependencies
 update:; forge update
 
 build:; forge build
 
-test :; forge test 
+test :; forge test
 
 snapshot :; forge snapshot
 
@@ -33,6 +33,6 @@ scope :; tree ./src/ | sed 's/└/#/g; s/──/--/g; s/├/#/g; s/│ /|/g; s/�
 
 scopefile :; @tree ./src/ | sed 's/└/#/g' | awk -F '── ' '!/\.sol$$/ { path[int((length($$0) - length($$2))/2)] = $$2; next } { p = "src"; for(i=2; i<=int((length($$0) - length($$2))/2); i++) if (path[i] != "") p = p "/" path[i]; print p "/" $$2; }' > scope.txt
 
-slither :; slither . --config-file slither.config.json 
+slither :; slither . --config-file slither.config.json
 
 aderyn :; aderyn .


### PR DESCRIPTION
### **Title:**

`fix: Remove --no-commit flag from Makefile install command`

### **Description:**

#### **Summary**

This pull request fixes an issue in the `Makefile` where the `install` command fails to correctly install Foundry dependencies due to the `--no-commit` flag.

#### **Problem**

Currently, the `install` target in the `Makefile` uses `forge install --no-commit`. This prevents the dependencies (like `forge-std` and `openzeppelin-contracts`) from being properly added as git submodules. As a result, subsequent commands like `make build` or `forge test` will fail if the dependencies are not already present.

#### **Solution**

By removing the `--no-commit` flag from the `forge install` commands, this change ensures that the dependencies are correctly installed and committed as git submodules. This makes the `make install` command work as expected and allows for a smooth setup process for new contributors.

#### **How to Test**

1.  Ensure you have a clean working directory. You can run `make clean` and `rm -rf lib`.
2.  Run `make install` or `make`.
3.  Verify that the `lib` directory is created and populated with the dependencies.
4.  Check that the `.gitmodules` file is updated with the new submodules.
5.  Run `make build` or `make test` to confirm that the project compiles and tests pass with the newly installed dependencies.