### PR TITLE
Removed --no-commit flag in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit
+install :; forge install foundry-rs/forge-std && forge install openzeppelin/openzeppelin-contracts 
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
Error: unexpected argument '--no-commit' found when running 'make'

The error is because newer versions of Foundry don’t support --no-commit anymore.

✅ Solution: Removed --no-commit flag in make file

forge install foundry-rs/forge-std \
&& forge install openzeppelin/openzeppelin-contracts@v3.4.0 \

Issue [14](https://github.com/Cyfrin/5-t-swap-audit/issues/14 )